### PR TITLE
Replace `uniqid` with `random_bytes`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 
     "require": {
         "php":               ">=5.5",
-        "guzzlehttp/guzzle": ">=6.0"
+        "guzzlehttp/guzzle": ">=6.0",
+        "paragonie/random_compat": ">=2"
     },
 
     "autoload": {

--- a/src/EightPoints/Guzzle/WsseAuthMiddleware.php
+++ b/src/EightPoints/Guzzle/WsseAuthMiddleware.php
@@ -212,6 +212,6 @@ class WsseAuthMiddleware
      */
     public function generateNonce()
     {
-        return base64_encode(hash('sha512', uniqid(true)));
+        return base64_encode(random_bytes(128));
     }
 }


### PR DESCRIPTION
I've been working with a system made up of multiple PHP applications talking to a centralized API using WSSE authentication.  Under load a very small percentage of these internal API calls will fail with a "reused nonce" error, and the cause appears to be `uniqid`:

https://github.com/8p/guzzle-wsse-middleware/blob/3998dae6fed29f2d3384024764046b63a764ddda/src/EightPoints/Guzzle/WsseAuthMiddleware.php#L213-L216

`uniqid(true)` is basically just [`microtime()` split and hex-encoded](https://github.com/php/php-src/blob/623911f993f39ebbe75abe2771fc89faf6b15b9b/ext/standard/uniqid.c#L80), with a prefix of 1 (`(string)true`).  So we suspect that this is caused by two API calls from different parts of the system executing at _exactly_ the same time. 

This PR swaps out `sha512(uniqid)` for `random_bytes(128)`.  

